### PR TITLE
fix index exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,8 +29,14 @@ export { environment };
 import * as requests from "./requests";
 export { requests };
 
+import * as responses from "./responses";
+export { responses };
+
 import * as promises from "./promises";
 export { promises };
+
+import * as request_middleware from "./request_middleware";
+export { request_middleware };
 
 import * as tasks from "./tasks";
 export { tasks };
@@ -41,5 +47,17 @@ export { backoff };
 import * as units from "./units";
 export { units };
 
+import * as express from "./express";
+export { express };
+
+import * as pot from "./pot";
+export { pot };
+
 import * as fetch from "./fetch";
 export { fetch };
+
+import * as OptionEither from "./OptionEither";
+export { OptionEither };
+
+import * as OptionValidation from "./OptionValidation";
+export { OptionValidation };


### PR DESCRIPTION
this is odd, as in the io project we used to import "italia-ts-commons/lib/<submodule>" but
we have got *some* exports at the root level. (this is the reason you opt out italia-ts-commons here:
https://github.com/teamdigitale/io-tslint-rules/blob/master/strong.json#L19).

maybe we should get rid of the index here if we plan to continue importing from submodules...
