### PR TITLE
[#167976266] Fix readableReporter

### DIFF
--- a/src/__tests__/reporters.test.ts
+++ b/src/__tests__/reporters.test.ts
@@ -9,6 +9,7 @@ import { NonNegativeNumber } from "../numbers";
 
 import { strictInterfaceWithOptionals } from "../types";
 
+import { left } from "fp-ts/lib/Either";
 import { ReadableReporter } from "../reporters";
 
 const TestType = t.interface(
@@ -77,5 +78,13 @@ describe("ReadableReporter", () => {
     const validation = aType.decode({ foo: true, x: true });
     const res = ReadableReporter.report(validation);
     expect(res).toEqual(["value [true] at [root.x] is not a known property"]);
+  });
+
+  it("should report validation errors on Errors with empty Context", () => {
+    const errors = left([{ context: [], value: "some value" }]);
+    const errorsReport = ReadableReporter.report(errors);
+    expect(errorsReport).toEqual([
+      'value ["some value"] at [root] (decoder info n/a)'
+    ]);
   });
 });

--- a/src/reporters.ts
+++ b/src/reporters.ts
@@ -11,6 +11,9 @@ import { Reporter } from "io-ts/lib/Reporter";
  *   ".c.b is not a non empty string"
  */
 function getContextPath(context: Context): string {
+  if (context.length === 0) {
+    return "] (decoder info n/a)";
+  }
   const keysPath = context.map(({ key }) => key).join(".");
   const lastType = context[context.length - 1].type;
 


### PR DESCRIPTION
This PR aims to fix readableReporter when Context is empty.
An exception occurs when Context (array of ContextEntry) is empty and **_getContextPath_** tries
to access the last item 